### PR TITLE
Updated server to handle 2 reviews routes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2768,6 +2768,14 @@
       "integrity": "sha512-4Hk6iSA/H90rtiPoCpSkeJxNWCPBf7szwVvaUqrPdxo0j2Y04suHK9jPKXaE3WI7OET6wBSwsWw7FDc1DBq7iQ==",
       "dev": true
     },
+    "axios": {
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.24.0.tgz",
+      "integrity": "sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==",
+      "requires": {
+        "follow-redirects": "^1.14.4"
+      }
+    },
     "axobject-query": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-2.2.0.tgz",
@@ -4852,6 +4860,11 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.2.tgz",
       "integrity": "sha512-JaTY/wtrcSyvXJl4IMFHPKyFur1sE9AUqc0QnhOaJ0CxHtAoIV8pYDzeEfAaNEtGkOfq4gr3LBFmdXW5mOQFnA==",
       "dev": true
+    },
+    "follow-redirects": {
+      "version": "1.14.5",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.5.tgz",
+      "integrity": "sha512-wtphSXy7d4/OR+MvIFbCVBDzZ5520qV8XfPklSN5QtxuMUJZ+b0Wnst1e1lCDocfzuCkHqj8k0FpZqO+UIaKNA=="
     },
     "form-data": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.16.0",
+    "axios": "^0.24.0",
     "dotenv": "^10.0.0",
     "express": "^4.17.1",
     "lodash": "^4.17.21",

--- a/server/controllers/reviewsController.js
+++ b/server/controllers/reviewsController.js
@@ -17,7 +17,8 @@ exports.review_get = (req, res) => {
     sort,
   })}`, config)
     .then((response) => response.data)
-    .then((data) => res.send(data));
+    .then((data) => res.send(data))
+    .catch(() => res.sendStatus(500));
 };
 
 exports.review_get_meta = (req, res) => {
@@ -31,5 +32,6 @@ exports.review_get_meta = (req, res) => {
     product_id,
   })}`, config)
     .then((response) => response.data)
-    .then((data) => res.send(data));
+    .then((data) => res.send(data))
+    .catch(() => res.sendStatus(500));
 };

--- a/server/controllers/reviewsController.js
+++ b/server/controllers/reviewsController.js
@@ -1,0 +1,32 @@
+/* eslint-disable camelcase */
+const axios = require('axios');
+
+exports.review_get = (req, res) => {
+  const { product_id, page, count } = req.params;
+
+  const config = {
+    headers: { Authorization: process.env.TOKEN },
+  };
+
+  axios.get(`https://app-hrsei-api.herokuapp.com/api/fec2/hr-sfo/reviews/?${new URLSearchParams({
+    product_id,
+    page,
+    count,
+  })}`, config)
+    .then((response) => response.data)
+    .then((data) => res.send(data));
+};
+
+exports.review_get_meta = (req, res) => {
+  const { product_id } = req.params;
+
+  const config = {
+    headers: { Authorization: process.env.TOKEN },
+  };
+
+  axios.get(`https://app-hrsei-api.herokuapp.com/api/fec2/hr-sfo/reviews/meta/?${new URLSearchParams({
+    product_id,
+  })}`, config)
+    .then((response) => response.data)
+    .then((data) => res.send(data));
+};

--- a/server/controllers/reviewsController.js
+++ b/server/controllers/reviewsController.js
@@ -2,7 +2,9 @@
 const axios = require('axios');
 
 exports.review_get = (req, res) => {
-  const { product_id, page, count } = req.params;
+  const {
+    product_id, page, count, sort,
+  } = req.params;
 
   const config = {
     headers: { Authorization: process.env.TOKEN },
@@ -12,6 +14,7 @@ exports.review_get = (req, res) => {
     product_id,
     page,
     count,
+    sort,
   })}`, config)
     .then((response) => response.data)
     .then((data) => res.send(data));

--- a/server/index.js
+++ b/server/index.js
@@ -1,10 +1,15 @@
+require('dotenv').config();
+
 const express = require('express');
 const path = require('path');
+const reviewRouter = require('./routes/reviews');
 
 const app = express();
 const port = 3000;
 
 app.use(express.static(path.join(__dirname, '/../public')));
+
+app.use('/reviews', reviewRouter);
 
 app.listen(port, () => {
   console.log(`app listening at http://localhost:${port}`);

--- a/server/routes/reviews.js
+++ b/server/routes/reviews.js
@@ -3,7 +3,7 @@ const reviewsController = require('../controllers/reviewsController');
 
 const router = express.Router();
 
-router.get('/:product_id/:page/:count', reviewsController.review_get);
+router.get('/:product_id/:page/:count/:sort', reviewsController.review_get);
 router.get('/meta/:product_id', reviewsController.review_get_meta);
 
 module.exports = router;

--- a/server/routes/reviews.js
+++ b/server/routes/reviews.js
@@ -1,0 +1,9 @@
+const express = require('express');
+const reviewsController = require('../controllers/reviewsController');
+
+const router = express.Router();
+
+router.get('/:product_id/:page/:count', reviewsController.review_get);
+router.get('/meta/:product_id', reviewsController.review_get_meta);
+
+module.exports = router;


### PR DESCRIPTION
Updated server to handle two routes:

- `/reviews/:product_id/:page/:count/:sort`
- `/reviews/meta/:product_id`

You can test this out in Postman after starting the server ex. 

- http://localhost:3000/reviews/61576/1/5/relevance will pull 5 most relevant reviews for a product
- http://localhost:3000/reviews/meta/61576 will reviews meta info for product

Check out the Reviews API info page if you want to test out different options.

These params are required but I will have default params on the client side.

Additional Info:

- `axios` installed
